### PR TITLE
Feature/publish custom ticks and tick data

### DIFF
--- a/.github/workflows/push-docker-transactions-producer-snapshot.yaml
+++ b/.github/workflows/push-docker-transactions-producer-snapshot.yaml
@@ -3,7 +3,7 @@ name: Release transactions-producer
 on:
   push:
     branches:
-      - feature/reduce-processing-delay
+      - feature/publish-custom-ticks
 
 jobs:
   docker-publish:

--- a/tick-data-publisher/sync/tick_data_processor.go
+++ b/tick-data-publisher/sync/tick_data_processor.go
@@ -58,6 +58,19 @@ func (p *TickDataProcessor) StartProcessing() {
 	}
 }
 
+func (p *TickDataProcessor) PublishCustomTicks(ticks []uint32) error {
+	log.Printf("[INFO] publishing custom ticks")
+	ctx := context.Background()
+	for _, tick := range ticks {
+		err := p.processTick(ctx, tick)
+		if err != nil {
+			return errors.Wrapf(err, "processing tick [%d]", tick)
+		}
+		log.Printf("Published tick [%d].", tick)
+	}
+	return nil
+}
+
 func (p *TickDataProcessor) process() error {
 	ctx := context.Background()
 	status, err := p.archiveClient.GetStatus(ctx)

--- a/transactions-producer/app/transactions-producer/main.go
+++ b/transactions-producer/app/transactions-producer/main.go
@@ -49,6 +49,7 @@ func run() error {
 		ArchiverReadTimeout                 time.Duration `conf:"default:20s"`
 		BatchSize                           int           `conf:"default:100"`
 		NrWorkers                           int           `conf:"default:20"`
+		PublishCustomTicks                  []uint32      `conf:"optional"`
 		OverrideLastProcessedTick           bool          `conf:"default:false"`
 		OverrideLastProcessedTickEpochValue uint32        `conf:"default:155"`
 		OverrideLastProcessedTickValue      uint32        `conf:"default:22669394"`
@@ -92,6 +93,8 @@ func run() error {
 	}
 
 	if cfg.OverrideLastProcessedTick {
+		log.Printf("main: overriding last processed tick with [%d] and epoch [%d].",
+			cfg.OverrideLastProcessedTickValue, cfg.OverrideLastProcessedTickEpochValue)
 		if err := procStore.SetLastProcessedTick(cfg.OverrideLastProcessedTickEpochValue, cfg.OverrideLastProcessedTickValue); err != nil {
 			return fmt.Errorf("setting last processed tick: %v", err)
 		}
@@ -128,9 +131,21 @@ func run() error {
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	procErrors := make(chan error, 1)
-	go func() {
-		procErrors <- proc.Start(cfg.NrWorkers)
-	}()
+	if len(cfg.PublishCustomTicks) > 0 {
+		log.Printf("main: publishing custom ticks: %v", cfg.PublishCustomTicks)
+		go func() {
+			err = proc.PublishSingleTicks(cfg.PublishCustomTicks)
+			if err != nil {
+				procErrors <- err
+			} else {
+				log.Printf("main: finished processing without error.")
+			}
+		}()
+	} else {
+		go func() {
+			procErrors <- proc.Start(cfg.NrWorkers)
+		}()
+	}
 
 	serverErr := make(chan error, 1)
 	go func() {

--- a/transactions-producer/app/transactions-producer/main.go
+++ b/transactions-producer/app/transactions-producer/main.go
@@ -179,7 +179,11 @@ func run() error {
 		case <-shutdown:
 			return errors.New("shutting down")
 		case err := <-procErrors:
-			return fmt.Errorf("processing error: %v", err)
+			if err != nil {
+				return fmt.Errorf("processing error: %v", err)
+			} else {
+				return fmt.Errorf("finished processing")
+			}
 		case err := <-serverErr:
 			return fmt.Errorf("server error: %v", err)
 		}

--- a/transactions-producer/domain/processor.go
+++ b/transactions-producer/domain/processor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/qubic/transactions-producer/entities"
 	"go.uber.org/zap"
+	"log"
 	"sync/atomic"
 	"time"
 )
@@ -96,6 +97,8 @@ func (p *Processor) PublishSingleTicks(ticks []uint32) error {
 		if err != nil {
 			return fmt.Errorf("inserting batch: %v", err)
 		}
+
+		log.Printf("Published transactions for tick [%d].", tick)
 	}
 	return nil
 }

--- a/transactions-producer/domain/processor.go
+++ b/transactions-producer/domain/processor.go
@@ -66,6 +66,40 @@ func (p *Processor) Start(nrWorkers int) error {
 	}
 }
 
+func (p *Processor) PublishSingleTicks(ticks []uint32) error {
+	intervals, e := p.fetcher.GetProcessedTickIntervalsPerEpoch(context.Background())
+	if e != nil {
+		return fmt.Errorf("getting tick intervals: %v", e)
+	}
+
+	for _, tick := range ticks {
+
+		epoch, err := getEpochForTick(tick, intervals)
+		if err != nil {
+			return fmt.Errorf("getting epoch for tick [%d]: %v", tick, err)
+		}
+
+		transactions, err := p.fetcher.GetTickTransactions(context.Background(), tick)
+		if err != nil {
+			return fmt.Errorf("fetching transactions: %v", err)
+		}
+
+		tickTransactions := []entities.TickTransactions{
+			{
+				Epoch:        epoch,
+				TickNumber:   tick,
+				Transactions: transactions,
+			},
+		}
+
+		err = p.publisher.PublishTickTransactions(tickTransactions)
+		if err != nil {
+			return fmt.Errorf("inserting batch: %v", err)
+		}
+	}
+	return nil
+}
+
 func (p *Processor) runCycle(nrWorkers int) error {
 	epochs, err := p.fetcher.GetProcessedTickIntervalsPerEpoch(context.Background())
 	if err != nil {
@@ -260,4 +294,15 @@ func (p *Processor) gatherTickTransactionsBatch(epoch, startTick uint32, epochTi
 	}
 
 	return tickTransactionsBatch, tick, nil
+}
+
+func getEpochForTick(tick uint32, intervals []entities.ProcessedTickIntervalsPerEpoch) (uint32, error) {
+	for _, epochIntervals := range intervals {
+		for _, interval := range epochIntervals.Intervals {
+			if interval.InitialProcessedTick <= tick && interval.LastProcessedTick >= tick {
+				return epochIntervals.Epoch, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("found no epoch")
 }


### PR DESCRIPTION
Adapt transactions and tick data publisher to optionally publish a list of custom ticks to be able to (re-)publish missing or erroneous data.