### PR TITLE
WIP Exit on non-retriable error

### DIFF
--- a/transactions-producer/external/kafka/client.go
+++ b/transactions-producer/external/kafka/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -57,7 +56,7 @@ func (kc *Client) PublishTickTransactions(tickTransactions []entities.TickTransa
 
 	for err := range errorChannel {
 		if err != nil {
-			return errors.New("encountered errors while producing tick transaction records")
+			return fmt.Errorf("producing transactions record: %w", err)
 		}
 	}
 


### PR DESCRIPTION
@0xluk I would like to try to exit the application when an error occurs that is not retriable. But I don't know how we should propagate the error to the top loop to gracefully exit. The fatal log is probably not a good choice, I only created it as a discussion basis. Let's this discuss face to face.